### PR TITLE
Switch docker-compose volume from EFS to S3

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ The web interface presents a login form and only proceeds once a valid
 username/password pair is supplied.
 
 Both servers read and write job data and model weights from a shared storage
-location. Mount an EFS volume into each container and ensure both processes
-point to the same path. The base directory defaults to `/mnt/efs` but can be
+location. Mount an S3 bucket into each container and ensure both processes
+point to the same path. The base directory defaults to `/mnt/s3` but can be
 overridden with the `SHARED_DIR` environment variable.
 
 When a user logs in, Server1 starts a dedicated GPU EC2 instance (e.g.,
@@ -29,7 +29,7 @@ appear.
 
 ```
 docker run -it --rm -p 5050:5050 \
-  -v /path/on/efs:/mnt/efs \
+  -v /path/on/s3:/mnt/s3 \
   -e AWS_REGION="us-east-1" \
   -e GPU_INSTANCE_ID="i-xxxxxxxx" \
   -e APP_USER1="user_a" -e APP_PASS1="pass_a" \

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -9,7 +9,7 @@ services:
     ports:
       - "5000:5000"
     volumes:
-      - ./shared:/mnt/efs
+      - ./shared:/mnt/s3
     environment:
       - AWS_REGION=${AWS_REGION}
       - GPU_INSTANCE_ID=${GPU_INSTANCE_ID}
@@ -26,4 +26,4 @@ services:
           devices:
             - capabilities: [gpu]
     volumes:
-      - ./shared:/mnt/efs
+      - ./shared:/mnt/s3

--- a/server1/app.py
+++ b/server1/app.py
@@ -28,10 +28,10 @@ import pillow_heif  # enables HEIC/HEIF decode in Pillow
 # -------------------------
 # Paths / Constants
 # -------------------------
-# Base directory for shared storage. Defaults to "/mnt/efs" but can be
+# Base directory for shared storage. Defaults to "/mnt/s3" but can be
 # overridden via the SHARED_DIR environment variable so both servers can point
-# to a common network location (e.g., an EFS mount).
-SHARED_DIR   = os.getenv("SHARED_DIR", "/mnt/efs")
+# to a common network location (e.g., an S3 mount).
+SHARED_DIR   = os.getenv("SHARED_DIR", "/mnt/s3")
 INPUT_DIR    = os.path.join(SHARED_DIR, "input")              # originals (PNG-normalized)
 RESIZED_DIR  = os.path.join(SHARED_DIR, "resized")            # ≤1024 for SAM
 MASKS_DIR    = os.path.join(SHARED_DIR, "output", "masks")    # from Server2

--- a/server2/worker.py
+++ b/server2/worker.py
@@ -41,9 +41,9 @@ except Exception:  # pragma: no cover - torch may not be installed
 # Config / directories
 # -------------------------
 # Base directory for shared storage, overridable via SHARED_DIR env var to
-# point at a network-mounted location (e.g., EFS) accessible from both
+# point at a network-mounted location (e.g., S3) accessible from both
 # Server1 and this GPU worker.
-SHARED_DIR = os.getenv("SHARED_DIR", "/mnt/efs")
+SHARED_DIR = os.getenv("SHARED_DIR", "/mnt/s3")
 RESIZED_DIR = os.path.join(SHARED_DIR, "resized")
 MASKS_DIR = os.path.join(SHARED_DIR, "output", "masks")
 SMALLS_DIR = os.path.join(SHARED_DIR, "output", "smalls")


### PR DESCRIPTION
## Summary
- replace EFS mounts with S3 mounts in docker-compose configuration
- default shared directory moved to `/mnt/s3` in both servers
- documentation updated for S3 usage

## Testing
- `python -m py_compile server1/app.py server2/worker.py`
- `yamllint docker-compose.yaml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68be21ac4690832eb0ad8ed8c93d3e01