### PR TITLE
Add serve entrypoint script for SageMaker

### DIFF
--- a/Server2.Dockerfile
+++ b/Server2.Dockerfile
@@ -13,9 +13,13 @@ RUN pip3 install --no-cache-dir torch==2.3.1+cu121 torchvision==0.18.1+cu121 \
 COPY server2/requirements.txt /tmp/
 RUN pip3 install --no-cache-dir -r /tmp/requirements.txt
 
+# Serve entrypoint for SageMaker
+COPY server2/serve /usr/local/bin/serve
+RUN chmod +x /usr/local/bin/serve
+
 # Application code
 WORKDIR /opt/program
 COPY server2/app.py .
 COPY server2/worker.py .
 
-CMD ["gunicorn", "--workers", "1", "--timeout", "3600", "--bind", "0.0.0.0:8080", "app:app"]
+CMD ["serve"]

--- a/server2/serve
+++ b/server2/serve
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -e
+
+exec gunicorn --workers 1 --timeout 3600 --bind 0.0.0.0:8080 app:app


### PR DESCRIPTION
## Summary
- allow SageMaker to run container by providing `serve` script
- reference new script in Dockerfile so gunicorn starts via `serve`

## Testing
- `python -m py_compile server2/app.py server2/worker.py`


------
https://chatgpt.com/codex/tasks/task_e_68be2d36b74c832e8a46a9a2daf32469