### PR TITLE
Log S3 file detection in SageMaker worker and document AWS env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,21 @@ new images and processes them as they appear. Heavy models
 (`segment-anything`, `ultralytics`, `rembg[gpu]`) are imported at module load
 time so they remain in memory while the instance is running.
 
+### Environment Variables
+
+Both Server1 and the SageMaker container require AWS credentials and region
+configuration to interact with services such as S3, EC2, and Secrets Manager.
+Provide these via one of the standard AWS mechanisms (environment variables,
+credentials files, or IAM roles). When using environment variables, set:
+
+* `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` (and `AWS_SESSION_TOKEN` if using
+  temporary credentials)
+* `AWS_REGION` or `AWS_DEFAULT_REGION`
+
+If your network uses a proxy, also configure `HTTPS_PROXY`/`HTTP_PROXY` so
+`botocore` can reach AWS endpoints. The `SHARED_DIR` variable may be set to change
+the mount point for the shared S3 directory.
+
 ### Models
 
 When Server1 starts it ensures required model weights are present under

--- a/server2/worker.py
+++ b/server2/worker.py
@@ -419,15 +419,14 @@ def process_new_images() -> int:
     processed = load_processed_set()
     settings = load_settings()
     files = [f for f in os.listdir(RESIZED_DIR) if f.endswith((".png", ".jpg", ".jpeg"))]
-    if not files:
-        print("[Worker] No pages found")
+    new_files = [f for f in files if os.path.splitext(f)[0] not in processed]
+    if not new_files:
+        print("[Worker] No new files found on S3")
         return 0
-    print(f"[Worker] Found {len(files)} page(s): {files}")
+    print(f"[Worker] Found {len(new_files)} new file(s) on S3: {new_files}")
     count = 0
-    for f in files:
+    for f in new_files:
         base = os.path.splitext(f)[0]
-        if base in processed:
-            continue
         file_path = os.path.join(RESIZED_DIR, f)
         start = time.process_time()
         print(f"[Worker] Processing {f} ...")


### PR DESCRIPTION
## Summary
- log newly discovered files in the SageMaker worker loop
- document required AWS credential and region environment variables, plus proxy/SHARED_DIR notes

## Testing
- `python -m py_compile server2/worker.py`


------
https://chatgpt.com/codex/tasks/task_e_68be34eecbb4832eab6b4acb0453a01d