### PR TITLE
Switch to headless OpenCV and remove GUI libs

### DIFF
--- a/Server1.Dockerfile
+++ b/Server1.Dockerfile
@@ -4,7 +4,6 @@ FROM python:3.10-slim
 WORKDIR /app
 
 RUN apt-get update && apt-get install -y \
-    libgl1 \
     libglib2.0-0 \
     && rm -rf /var/lib/apt/lists/*
 

--- a/Server2.Dockerfile
+++ b/Server2.Dockerfile
@@ -2,7 +2,7 @@ FROM nvidia/cuda:12.2.0-runtime-ubuntu22.04
 
 # System dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    python3 python3-pip libglib2.0-0 libgl1 libsm6 libxext6 libxrender1 git \
+    python3 python3-pip libglib2.0-0 git \
     && rm -rf /var/lib/apt/lists/*
 
 # Python dependencies (torch compiled for CUDA 12.1)

--- a/server1/requirements.txt
+++ b/server1/requirements.txt
@@ -1,7 +1,7 @@
 flask
 requests
 pillow
-opencv-python
+opencv-python-headless
 numpy
 pillow-heif
 boto3

--- a/server2/requirements.txt
+++ b/server2/requirements.txt
@@ -1,4 +1,4 @@
-opencv-python
+opencv-python-headless
 numpy
 git+https://github.com/facebookresearch/segment-anything.git
 rembg[gpu]


### PR DESCRIPTION
## Summary
- Replace `opencv-python` with headless builds
- Drop GUI-related system packages from Dockerfiles

## Testing
- `python -m py_compile server1/app.py server2/app.py server2/worker.py`


------
https://chatgpt.com/codex/tasks/task_e_68bf7f826a58832ea0a7e798846fa088