### PR TITLE
Support per-user directories and shared models for SAM worker

### DIFF
--- a/server1/app.py
+++ b/server1/app.py
@@ -219,7 +219,9 @@ def _download_file(url: str, dest: str) -> None:
             os.remove(tmp)
 
 
-ENABLE_MODEL_DOWNLOADS = os.getenv("ENABLE_MODEL_DOWNLOADS") == "0"
+# Model downloads are enabled by default. Set ENABLE_MODEL_DOWNLOADS=0 to skip
+# fetching large files at startup.
+ENABLE_MODEL_DOWNLOADS = os.getenv("ENABLE_MODEL_DOWNLOADS", "1") != "0"
 
 def ensure_models() -> None:
     models = {


### PR DESCRIPTION
## Summary
- ensure model downloads default to enabled and provide a toggle via `ENABLE_MODEL_DOWNLOADS`
- restructure GPU worker to operate on per-user folders beneath the shared directory
- share a single models directory across users and make worker loop over all usernames

## Testing
- `python -m py_compile server2/worker.py server1/app.py server2/app.py`


------
https://chatgpt.com/codex/tasks/task_e_68bf913b3d34832ebbd7a06f08493c65