### PR TITLE
fix: unbuffer server1 logs

### DIFF
--- a/Server1.Dockerfile
+++ b/Server1.Dockerfile
@@ -1,6 +1,11 @@
 # Server1.Dockerfile
 FROM python:3.10-slim
 
+# Ensure Python output is sent straight to the console so Docker logs
+# are emitted in real time.  Without this the application appeared to
+# hang because stdout was block-buffered until the buffer filled.
+ENV PYTHONUNBUFFERED=1
+
 WORKDIR /app
 
 RUN apt-get update && apt-get install -y \
@@ -22,4 +27,5 @@ COPY server1/ .
 # Flask runs on port 8080
 EXPOSE 8080
 
-CMD ["python", "app.py"]
+# Run the app with unbuffered output so log messages appear immediately
+CMD ["python", "-u", "app.py"]


### PR DESCRIPTION
## Summary
- ensure Python output is unbuffered in Server1 so logs stream immediately

## Testing
- `python -m py_compile server1/app.py`


------
https://chatgpt.com/codex/tasks/task_e_68c072c0b714832ea9e80a516fc21747