### PR TITLE
Fix libGL dependency missing in Server2 Dockerfile

### DIFF
--- a/Server2.Dockerfile
+++ b/Server2.Dockerfile
@@ -6,8 +6,8 @@ ENV DEBIAN_FRONTEND=noninteractive \
 
 # System deps
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    python3 python3-pip ca-certificates libglib2.0-0 git \
- && rm -rf /var/lib/apt/lists/*
+    python3 python3-pip ca-certificates libglib2.0-0 libgl1 git \
+    && rm -rf /var/lib/apt/lists/*
 
 # Make sure pip is new enough to handle PyTorch indexes
 RUN python3 -m pip install --upgrade pip setuptools wheel


### PR DESCRIPTION
## Summary
- install `libgl1` so OpenCV can load in the server2 Sagemaker image

## Testing
- `python3 -m py_compile server2/app.py server2/worker.py`

------
https://chatgpt.com/codex/tasks/task_e_68c078742c74832e8a34d7e5687674ae