### PR TITLE
Ensure models stored on S3 and accessed by Sage server

### DIFF
--- a/server1/app.py
+++ b/server1/app.py
@@ -179,6 +179,8 @@ if s3_client:
     try:
         s3_client.head_bucket(Bucket=S3_BUCKET)
         print(f"[s3] bucket '{S3_BUCKET}' accessible")
+        # ensure shared models prefix exists so weights are stored on S3
+        s3_client.put_object(Bucket=S3_BUCKET, Key="models/")
     except Exception as e:
         print(f"[s3] bucket '{S3_BUCKET}' not accessible: {e}")
         s3_client = None
@@ -231,8 +233,25 @@ def ensure_models() -> None:
         "yolov8n-seg.pt": "https://github.com/ultralytics/assets/releases/download/v0.0.0/yolov8n-seg.pt",
     }
     for fname, url in models.items():
-        print(f'Downloading {fname}')
-        _download_file(url, os.path.join(MODELS_DIR, fname))
+        local_path = os.path.join(MODELS_DIR, fname)
+        s3_key = f"models/{fname}"
+        if s3_client and S3_BUCKET:
+            try:
+                s3_client.head_object(Bucket=S3_BUCKET, Key=s3_key)
+                if not os.path.exists(local_path):
+                    s3_client.download_file(S3_BUCKET, s3_key, local_path)
+                    print(f"Downloaded {fname} from S3")
+                    continue
+            except ClientError:
+                pass
+        if not os.path.exists(local_path):
+            print(f"Downloading {fname}")
+            _download_file(url, local_path)
+            if s3_client and S3_BUCKET:
+                try:
+                    s3_client.upload_file(local_path, S3_BUCKET, s3_key)
+                except Exception as e:  # pragma: no cover - best effort
+                    print(f"[s3] upload failed for {fname}: {e}")
 
 
 if ENABLE_MODEL_DOWNLOADS:

--- a/server2/worker.py
+++ b/server2/worker.py
@@ -88,9 +88,26 @@ def _mount_s3_from_secret(mount_point: str) -> None:
 SHARED_DIR = os.getenv("SHARED_DIR", "/mnt/s3")
 _mount_s3_from_secret(SHARED_DIR)
 
+s3_client = boto3.client("s3", region_name=AWS_REGION) if S3_BUCKET else None
+
 # All models are shared across users and live in a common directory.
 MODELS_DIR = os.path.join(SHARED_DIR, "models")
 os.makedirs(MODELS_DIR, exist_ok=True)
+if s3_client and S3_BUCKET:
+    try:
+        s3_client.put_object(Bucket=S3_BUCKET, Key="models/")
+    except Exception as e:  # pragma: no cover - best effort
+        print(f"[s3] ensure models prefix failed: {e}")
+    required = ["vit_l.pth", "birefnet-dis.onnx", "yolov8n.pt", "yolov8n-seg.pt"]
+    for fname in required:
+        local_path = os.path.join(MODELS_DIR, fname)
+        if not os.path.exists(local_path):
+            s3_key = f"models/{fname}"
+            try:
+                s3_client.download_file(S3_BUCKET, s3_key, local_path)
+                print(f"[s3] downloaded {s3_key} to {local_path}")
+            except Exception as e:  # pragma: no cover - best effort
+                print(f"[s3] failed to download {s3_key}: {e}")
 MODEL_PATH = os.path.join(MODELS_DIR, "vit_l.pth")
 YOLO_MODELS_DIR = MODELS_DIR
 


### PR DESCRIPTION
## Summary
- Ensure server1 creates and populates the `models/` prefix in S3 and syncs model files to the bucket.
- Make Sage worker mount and verify the S3 models directory, fetching required weights from S3 if absent.

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c0995f6838832eb36427c138e1c232