### PR TITLE
Install s3fs for S3 bucket mounting

### DIFF
--- a/Server1.Dockerfile
+++ b/Server1.Dockerfile
@@ -9,7 +9,7 @@ ENV PYTHONUNBUFFERED=1
 WORKDIR /app
 
 RUN apt-get update && apt-get install -y \
-    libglib2.0-0 \
+    libglib2.0-0 s3fs \
     && rm -rf /var/lib/apt/lists/*
 
 

--- a/Server2.Dockerfile
+++ b/Server2.Dockerfile
@@ -6,7 +6,7 @@ ENV DEBIAN_FRONTEND=noninteractive \
 
 # System deps
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    python3 python3-pip ca-certificates libglib2.0-0 libgl1 git \
+    python3 python3-pip ca-certificates libglib2.0-0 libgl1 git s3fs \
     && rm -rf /var/lib/apt/lists/*
 
 # Make sure pip is new enough to handle PyTorch indexes


### PR DESCRIPTION
## Summary
- Install s3fs in Server1 and Server2 Docker images so containers can mount shared S3 storage

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c0c7ec174c832ea322e8f0eca1bcf2