### PR TITLE
Use boto3 for S3 access

### DIFF
--- a/Server1.Dockerfile
+++ b/Server1.Dockerfile
@@ -9,7 +9,7 @@ ENV PYTHONUNBUFFERED=1
 WORKDIR /app
 
 RUN apt-get update && apt-get install -y \
-    libglib2.0-0 s3fs \
+    libglib2.0-0 \
     && rm -rf /var/lib/apt/lists/*
 
 

--- a/Server2.Dockerfile
+++ b/Server2.Dockerfile
@@ -6,7 +6,7 @@ ENV DEBIAN_FRONTEND=noninteractive \
 
 # System deps
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    python3 python3-pip ca-certificates libglib2.0-0 libgl1 git s3fs \
+    python3 python3-pip ca-certificates libglib2.0-0 libgl1 git \
     && rm -rf /var/lib/apt/lists/*
 
 # Make sure pip is new enough to handle PyTorch indexes

--- a/server1/app.py
+++ b/server1/app.py
@@ -30,7 +30,8 @@ import pillow_heif  # enables HEIC/HEIF decode in Pillow
 # -------------------------
 # Base directory for shared storage. Defaults to "/mnt/s3" but can be
 # overridden via the SHARED_DIR environment variable so both servers can point
-# to a common network location (e.g., an S3 mount).
+# to a common local path. S3 access is handled via boto3 rather than a mounted
+# filesystem.
 SHARED_DIR   = os.getenv("SHARED_DIR", "/mnt/s3")
 
 # Paths that depend on the logged-in user. They are initialized for a generic


### PR DESCRIPTION
## Summary
- remove s3fs dependency from server images
- rely on boto3 for S3 transfers in server2 and worker
- document boto3-based storage path in server1

## Testing
- `python -m py_compile server1/app.py server2/app.py server2/worker.py`


------
https://chatgpt.com/codex/tasks/task_e_68c0d43a3bac832e9ada88a4774a2314