### PR TITLE
Disable server1 model downloads and notify SageMaker at startup

### DIFF
--- a/Server1.Dockerfile
+++ b/Server1.Dockerfile
@@ -5,6 +5,8 @@ FROM python:3.10-slim
 # are emitted in real time.  Without this the application appeared to
 # hang because stdout was block-buffered until the buffer filled.
 ENV PYTHONUNBUFFERED=1
+# Disable model downloads; SageMaker provides required weights
+ENV ENABLE_MODEL_DOWNLOADS=0
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary
- Prevent server1 from downloading model weights and rely on SageMaker instead
- Send a startup notification to the SageMaker endpoint when server1 launches
- Explicitly disable model downloads in the Server1 Dockerfile

## Testing
- `python -m py_compile server1/app.py`
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_68c0e20bc910832ea5151d5f6631af12