### PR TITLE
Add simple script to invoke SageMaker endpoint

### DIFF
--- a/trigger_sagemaker.sh
+++ b/trigger_sagemaker.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Simple script to invoke a SageMaker endpoint.
+# Usage: ./trigger_sagemaker.sh [endpoint_name] [input_json] [output_file]
+# Defaults: endpoint_name="sam-server2-endpoint", input_json="input.json", output_file="output.json"
+
+ENDPOINT_NAME="${1:-sam-server2-endpoint}"
+INPUT_FILE="${2:-input.json}"
+OUTPUT_FILE="${3:-output.json}"
+
+aws sagemaker-runtime invoke-endpoint \
+  --endpoint-name "$ENDPOINT_NAME" \
+  --body fileb://"$INPUT_FILE" \
+  --content-type application/json \
+  "$OUTPUT_FILE"
+
+cat "$OUTPUT_FILE"


### PR DESCRIPTION
## Summary
- add a minimal bash script to invoke a SageMaker endpoint from the local machine
- wire `/invocations` to run worker-based mask generation and crop extraction

## Testing
- `python -m py_compile server2/app.py`
- `bash -n trigger_sagemaker.sh`


------
https://chatgpt.com/codex/tasks/task_e_68c1583249b8832ebd2ba69f12c1ca5e