### PR TITLE
Use CUDA runtime with cuDNN 9

### DIFF
--- a/Server2.Dockerfile
+++ b/Server2.Dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:12.2.0-runtime-ubuntu22.04
+FROM nvidia/cuda:12.2.0-cudnn9-runtime-ubuntu22.04
 
 ENV DEBIAN_FRONTEND=noninteractive \
     PIP_NO_CACHE_DIR=1 \


### PR DESCRIPTION
## Summary
- ensure cuDNN 9 is present by basing the server2 image on a CUDA + cuDNN runtime image

## Testing
- `python3 -m py_compile server2/app.py server2/worker.py`
- `docker --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c18bb71cf4832e97b0accf796f0285