### PR TITLE
fix: use available cuda base image

### DIFF
--- a/Server2.Dockerfile
+++ b/Server2.Dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:12.2.0-cudnn9-runtime-ubuntu22.04
+FROM nvidia/cuda:12.2.0-cudnn8-runtime-ubuntu22.04
 
 ENV DEBIAN_FRONTEND=noninteractive \
     PIP_NO_CACHE_DIR=1 \


### PR DESCRIPTION
## Summary
- use existing nvidia/cuda image with cuDNN 8 instead of unavailable cuDNN 9

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c18d1aa8a8832e81b2fff3e967f775