### PR TITLE
Add future import to support Python 3.8 type annotations

### DIFF
--- a/server2/worker.py
+++ b/server2/worker.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import time
 import json


### PR DESCRIPTION
## Summary
- avoid "type object is not subscriptable" in Python 3.8 by deferring type hint evaluation

## Testing
- `python -m py_compile server2/worker.py`
- `python -m py_compile server2/app.py`
- `python -m py_compile server1/app.py`


------
https://chatgpt.com/codex/tasks/task_e_68c1a1db68b0832eae6245d6dc9e5e55