### PR TITLE
Fix resized watcher to monitor correct directory

### DIFF
--- a/server1/app.py
+++ b/server1/app.py
@@ -943,7 +943,7 @@ def resized_watcher_loop():
     while True:
         try:
             try:
-                users = os.listdir(USER_BASE)
+                users = os.listdir(SHARED_DIR)
             except OSError as e:
                 print(f"[resized_watcher] cannot access {SHARED_DIR}: {e}")
                 time.sleep(0.5)
@@ -967,8 +967,8 @@ def resized_watcher_loop():
                     print(f"[resized_watcher] cannot access {resized_dir}: {e}")
                     continue
                 for fname in files:
-                    print(f'found {fname} and launching a thread with run_sagemaker_job using arguments {stem} and {user}')
                     stem, _ = os.path.splitext(fname)
+                    print(f'found {fname} and launching a thread with run_sagemaker_job using arguments {stem} and {user}')
                     key = (user, stem)
                     if stem in processed or key in _processing_jobs:
                         continue


### PR DESCRIPTION
## Summary
- Watch resized_watcher_loop scan user directories under `SHARED_DIR` instead of the default `USER_BASE` path
- Avoid referencing `stem` before assignment by computing it prior to logging

## Testing
- `python -m py_compile server1/app.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c22542b95c832e972c6d8e0d6dae72