### PR TITLE
Fix indentation in resized watcher loop

### DIFF
--- a/server1/app.py
+++ b/server1/app.py
@@ -825,8 +825,6 @@ def resized_watcher_loop():
     while True:
         try:
             if not (s3_client and S3_BUCKET):
-            try:
-
                 time.sleep(0.5)
                 continue
             resp = s3_client.list_objects_v2(Bucket=S3_BUCKET, Delimiter="/")


### PR DESCRIPTION
## Summary
- fix indentation bug in server1 resized_watcher_loop

## Testing
- `python -m py_compile server1/app.py`


------
https://chatgpt.com/codex/tasks/task_e_68c232157348832e828c905bd0af6d99