### PR TITLE
Use server-sent events for S3 album updates

### DIFF
--- a/server1/templates/index.html
+++ b/server1/templates/index.html
@@ -362,9 +362,14 @@
       autoAddBiggestCrops(albums);
     }
 
-    // initial + polling (debounced while interacting)
+    // Initial load of albums and subscribe to server-sent events for updates
     refreshAlbums();
-    setInterval(()=>{ if(Date.now()-lastUserAction>1200) refreshAlbums(); }, 2000);
+    const albumEvents = new EventSource("/album_stream");
+    albumEvents.onmessage = () => {
+      if (Date.now() - lastUserAction > 1200) {
+        refreshAlbums();
+      }
+    };
 
    // ---------- Konva stage ----------
   const container = document.getElementById("canvasContainer");


### PR DESCRIPTION
## Summary
- Replace periodic polling with server-sent events so the UI refreshes albums when new S3 items arrive
- Notify SSE clients after processing new mask files

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c32ed4956c832e953732a76f092f03