### PR TITLE
Optimize thumbnails and render with React

### DIFF
--- a/server1/app.py
+++ b/server1/app.py
@@ -368,12 +368,13 @@ def require_login():
 # Helpers
 # -------------------------
 def normalize_to_png_bytes(pil_img: Image.Image, longest_side: int | None = None) -> bytes:
-    """Optionally resize to longest_side and return PNG bytes."""
+    """Optionally resize to longest_side and return an optimized PNG bytestring."""
     img = pil_img.convert("RGBA")
     if longest_side and max(img.size) > longest_side:
         img.thumbnail((longest_side, longest_side), Image.LANCZOS)
     buf = io.BytesIO()
-    img.save(buf, "PNG")
+    # optimize=True reduces file size without altering pixel data
+    img.save(buf, "PNG", optimize=True)
     return buf.getvalue()
 
 

--- a/server1/templates/index.html
+++ b/server1/templates/index.html
@@ -5,6 +5,9 @@
   <title>SAM Studio</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <script src="https://cdn.jsdelivr.net/npm/konva@9/konva.min.js"></script>
+  <!-- React for component-based UI rendering -->
+  <script crossorigin src="https://unpkg.com/react@18/umd/react.production.min.js"></script>
+  <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
   <style>
     :root{
       --bg:#0b0c10; --panel:#12141a; --muted:#1a1d25; --text:#e9eef7; --sub:#9fb0c7;
@@ -174,6 +177,18 @@
   </main>
 
   <script>
+    // React component to render a single thumbnail chip
+    function Thumb(props){
+      const c = props.crop;
+      return React.createElement("div", {className: "chip"},
+        React.createElement("img", {
+          src: c.thumb_url,
+          alt: c.file,
+          title: "Add to canvas",
+          onClick: function(){ addToCanvas(c.url); }
+        })
+      );
+    }
     // ---------- settings ----------
     async function loadSettings(){
       const r = await fetch("/get_settings"); const s = await r.json();
@@ -347,16 +362,12 @@
           const empty=document.createElement("div"); empty.className="chip"; empty.textContent="No clippings yet.";
           chips.appendChild(empty);
         }else{
-          a.crops.forEach(c=>{
-            const chip=document.createElement("div"); chip.className="chip";
-            const img=document.createElement("img");
-            img.src = c.thumb_url;
-            img.alt = c.file;
-            img.title = "Add to canvas";
-            // c.url points to the full-resolution clip; add it to the canvas when clicked
-            img.addEventListener("click", () => addToCanvas(c.url));
-            chip.appendChild(img); chips.appendChild(chip);
-          });
+          const root = ReactDOM.createRoot(chips);
+          root.render(
+            React.createElement(React.Fragment, null,
+              a.crops.map(c => React.createElement(Thumb, {key: c.file, crop: c}))
+            )
+          );
         }
         body.appendChild(chips);
 


### PR DESCRIPTION
## Summary
- Import React into server 1 frontend and render crop thumbnails via a Thumb component
- Optimize PNG generation with Pillow's optimize flag before uploading to S3

## Testing
- `python -m py_compile server1/app.py`


------
https://chatgpt.com/codex/tasks/task_e_68c360a231f0832e96399474de0c16eb